### PR TITLE
Simplified adding :versioned to list of allowed options

### DIFF
--- a/lib/mongoid/core_ext/fields/validators/macro.rb
+++ b/lib/mongoid/core_ext/fields/validators/macro.rb
@@ -2,9 +2,7 @@ module Mongoid
   module Fields
     module Validators
       module Macro
-        options = OPTIONS
-        send :remove_const, :OPTIONS
-        send :const_set, :OPTIONS, options + [:versioned]
+        OPTIONS << :versioned
       end
     end
   end

--- a/lib/mongoid/core_ext/relations/options.rb
+++ b/lib/mongoid/core_ext/relations/options.rb
@@ -1,9 +1,7 @@
 module Mongoid
   module Relations
     module Options
-      common = COMMON
-      send :remove_const, :COMMON
-      send :const_set, :COMMON, common + [:versioned]
+      COMMON << :versioned
     end
   end
 end


### PR DESCRIPTION
There is no need to redefine constant when you can just add to an existing one.
