### PR TITLE
Improve system that control number of versions

### DIFF
--- a/lib/mongoid/core_ext/versioning.rb
+++ b/lib/mongoid/core_ext/versioning.rb
@@ -42,18 +42,17 @@ module Mongoid
         )
         new_version._id = nil
         if version_max.present? && versions.length > version_max
-          deleted = versions.first
-          if deleted.respond_to?(:paranoid?) && deleted.paranoid?
-            versions.delete_one(deleted)
+          to_delete = versions.first
+          version_to_delete = to_delete.version
+          if to_delete.respond_to?(:paranoid?) && to_delete.paranoid?
+            versions.delete_one(to_delete)
 
             query = collection.find(atomic_selector)
             query.respond_to?(:update_one) ?
-              query.update_one({ "$pull" => { "versions" => { "version" => deleted.version }}}) :
-              query.update({ "$pull" => { "versions" => { "version" => deleted.version }}})
+              query.update_one({ "$pull" => { "versions" => { "version" => version_to_delete }}}) :
+              query.update({ "$pull" => { "versions" => { "version" => version_to_delete }}})
           else
-            versions.delete(deleted)
-            # version_to_delete = versions.first.version
-            # versions.where(version: version_to_delete).delete_all
+            versions.where(version: version_to_delete).delete_all
           end
         end
         self.version = (version || 1 ) + 1

--- a/lib/mongoid/core_ext/versioning.rb
+++ b/lib/mongoid/core_ext/versioning.rb
@@ -52,6 +52,8 @@ module Mongoid
               query.update({ "$pull" => { "versions" => { "version" => deleted.version }}})
           else
             versions.delete(deleted)
+            # version_to_delete = versions.first.version
+            # versions.where(version: version_to_delete).delete_all
           end
         end
         self.version = (version || 1 ) + 1

--- a/spec/mongoid/versioning_spec.rb
+++ b/spec/mongoid/versioning_spec.rb
@@ -384,16 +384,12 @@ describe Mongoid::Versioning do
             end
           end
 
-          let(:versions) do
-            page.versions
-          end
-
           it "only versions the maximum amount" do
             expect(page.reload.versions.count).to eq(5)
           end
 
           it "shifts the versions in order" do
-            expect(versions.last.title).to eq("8")
+            expect(page.reload.versions.last.title).to eq("8")
           end
 
           it "persists the version shifts" do

--- a/spec/mongoid/versioning_spec.rb
+++ b/spec/mongoid/versioning_spec.rb
@@ -389,7 +389,7 @@ describe Mongoid::Versioning do
           end
 
           it "only versions the maximum amount" do
-            expect(versions.count).to eq(5)
+            expect(page.reload.versions.count).to eq(5)
           end
 
           it "shifts the versions in order" do
@@ -398,6 +398,7 @@ describe Mongoid::Versioning do
 
           it "persists the version shifts" do
             expect(page.reload.versions.last.title).to eq("8")
+            expect(page.reload.versions.first.title).to eq("4")
           end
         end
 


### PR DESCRIPTION
The system that control the number of versions delete the whole version model when the number of max versions is achieved. 

When:
 versions.delete(deleted)

 is executed, all versions are deleted because mongo takes and object without ID and run a delete task, that delete all occurrences.

The current test are running because the values of the model are cached in testing. I have change also the test to avoid this. 