### PR TITLE
Change options validation method instead of altering constant for mongoid 6

### DIFF
--- a/lib/mongoid/core_ext/relations/options.rb
+++ b/lib/mongoid/core_ext/relations/options.rb
@@ -1,7 +1,21 @@
 module Mongoid
   module Relations
     module Options
-      COMMON << :versioned
+      VERSIONED_OPTIONS  = [:versioned].freeze
+
+      def validate!(options)
+        valid_options = options[:relation]::VALID_OPTIONS + COMMON + VERSIONED_OPTIONS
+        options.keys.each do |key|
+          if !valid_options.include?(key)
+            raise Errors::InvalidOptions.new(
+              options[:name],
+              key,
+              valid_options
+            )
+          end
+        end
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
Overwrite options validation method instead of altering constant.

Of course I see drawbacks in this solution - now option `versioned` is not passed inside everywhere where `COMMON` is called.

Also I see possible issue with other extensions that also want to have their options to be valid - in this approach we would have conflicts.

In ideal scenario I envision that there is `valid_relation_options` method, that would be extendable by any other gems with something like `super + [:my_options]` or in `mongoid` change `COMMON` options constant to a class method.... 

Also I was not able to run tests successfully since there is dependency on mongoid-paranoia, but it has no release for `mongoid-6`