### PR TITLE
COMMON is a frozen array, so we work around it

### DIFF
--- a/lib/mongoid/core_ext/relations/options.rb
+++ b/lib/mongoid/core_ext/relations/options.rb
@@ -1,7 +1,9 @@
 module Mongoid
   module Relations
-    module Options
-      COMMON = ([:versioned].concat(COMMON)).freeze
+    module Options  
+      after = ([:versioned].concat(COMMON)).freeze
+      remove_const(:COMMON)
+      COMMON = after
     end
   end
 end

--- a/lib/mongoid/core_ext/relations/options.rb
+++ b/lib/mongoid/core_ext/relations/options.rb
@@ -1,7 +1,7 @@
 module Mongoid
   module Relations
     module Options
-      COMMON << :versioned
+      COMMON = ([:versioned].concat(COMMON)).freeze
     end
   end
 end


### PR DESCRIPTION
Mongoid has opted to use a frozen object for Mongoid relation options; so what we do is to replace the COMMON variable with a new instance of it, with the added element, in this case :versioned