### PR TITLE
Updates to make it mongoid v6 compatible.

### DIFF
--- a/lib/mongoid/core_ext/relations/options.rb
+++ b/lib/mongoid/core_ext/relations/options.rb
@@ -1,7 +1,12 @@
 module Mongoid
   module Relations
     module Options
-      COMMON << :versioned
+      # The COMMON const is frozen since mongoid v6,
+      # and there is no easy way to override the common
+      # list of options for the relations being used inside
+      # the +validate!+ method. This hack solves it.
+      COMMON = self::COMMON + [:versioned]
+      COMMON.freeze
     end
   end
 end

--- a/lib/mongoid/core_ext/versioning.rb
+++ b/lib/mongoid/core_ext/versioning.rb
@@ -139,10 +139,11 @@ module Mongoid
         mongo_session.options
 
       _loading_revision do
-        self.class.unscoped
-          .with(options)
-          .where(_id: id)
-          .any_of({ version: version }, version: nil).first
+        self.class.with(options) do |m|
+          m.unscoped
+           .where(_id: id)
+           .any_of({ version: version }, version: nil).first
+        end
       end
     end
 


### PR DESCRIPTION
In Mongoid v6, the `Mongoid::Relations::Options::COMMON` const is now frozen. This const is used to validate whether the provided options for the relation is valid.

This commit hacks `:versioned` as a valid option into that frozen `COMMON` const.